### PR TITLE
Add docs/README.md as entrypoint for OctoAcme project management processes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,48 @@
+# OctoAcme Project Management Docs
+
+Welcome! This README provides an overview of the project management processes used at OctoAcme and quick links to all institutionally-approved process documents maintained in this repository.
+
+## Project Management Processes at OctoAcme
+
+OctoAcme uses a customer-first, iterative approach encompassing:
+- Clear definition of roles and responsibilities
+- Structured lifecycle (Initiation → Planning → Execution → Release → Retrospective/Continuous Improvement)
+- Dedicated processes for risk management, communication, and quality
+- Use of project boards, milestone tracking, and transparent documentation
+
+### Lifecycle (high-level)
+1. **Initiation:** Validate need, align stakeholders, define success.
+2. **Planning:** Break work into increments, estimate, and mitigate risks.
+3. **Execution & Tracking:** Deliver, review, test, and track progress.
+4. **Release & Deployment:** Ship safely with clear checklists.
+5. **Retrospective & Continuous Improvement:** Capture learnings and improve.
+
+See each process document for deep guidance.
+
+## Process Documents & Quick Links
+
+- [Project Management Overview](octoacme-project-management-overview.md)
+- [Project Initiation Guide](octoacme-project-initiation.md)
+- [Project Planning](octoacme-project-planning.md)
+- [Execution & Tracking](octoacme-execution-and-tracking.md)
+- [Risk Management & Communication](octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](octoacme-retrospective-and-continuous-improvement.md)
+- [Roles & Personas](octoacme-roles-and-personas.md)
+
+---
+
+Each document provides:
+- Summary and rationale
+- Clear checklist(s)
+- Team roles
+- Templates for key deliverables
+
+## How to Use
+1. Start with the [Project Management Overview](octoacme-project-management-overview.md) for an at-a-glance guide.
+2. Follow the process documents in order as your project moves through each phase.
+3. Keep this README up to date as processes evolve!
+
+---
+
+_Maintained collaboratively using Copilot Spaces to ensure everyone has equal access to best practices and living documentation._


### PR DESCRIPTION
…esses

This PR adds a new `docs/README.md` which serves as the discoverable entrypoint and index for all OctoAcme project management process documents as described in [Issue #2](https://github.com/gtothtcs/skills-scale-institutional-knowledge-using-copilot-spaces/issues/2).

- Summarizes the overall project management approach used at OctoAcme
- Provides quick links to each detailed process doc in the `docs/` folder
- Improves onboarding and discoverability for all teammates

cc: @gtothtcs

Closes [Issue #2](https://github.com/gtothtcs/skills-scale-institutional-knowledge-using-copilot-spaces/issues/2)